### PR TITLE
fix(dato-icon-button): add support for custom icon size as well

### DIFF
--- a/lib/src/icon-button/icon-button.component.ts
+++ b/lib/src/icon-button/icon-button.component.ts
@@ -22,14 +22,16 @@ export class DatoIconButtonComponent {
   @Input() datoIcon: string;
   @Input() datoIconColor: string;
 
-  constructor(@Attribute('datoSize') public datoSize, @Attribute('datoType') public datoType, @Attribute('datoCircle') public datoCircle, @Attribute('width') public width, @Attribute('height') public height, private host: ElementRef) {}
+  constructor(@Attribute('datoSize') public datoSize, @Attribute('datoType') public datoType, @Attribute('datoCircle') public datoCircle, @Attribute('width') public width, @Attribute('height') public height, @Attribute('iconWidth') public iconWidth, @Attribute('iconHeight') public iconHeight, private host: ElementRef) {}
 
   ngOnInit() {
     if (this.width || this.height) {
       const button = query('button', this.host.nativeElement);
-      const icon = query('dato-icon', this.host.nativeElement);
       setDimensions(this.width, this.height, button);
-      setDimensions(this.width, this.height, icon);
+    }
+    if (this.iconWidth || this.iconHeight || this.width || this.height) {
+      const icon = query('dato-icon', this.host.nativeElement);
+      setDimensions(this.iconWidth || this.width, this.iconHeight || this.height, icon);
     }
   }
 }

--- a/playground/src/app/components-gallery/previews/buttons-preview/buttons-preview.component.html
+++ b/playground/src/app/components-gallery/previews/buttons-preview/buttons-preview.component.html
@@ -318,15 +318,27 @@
       </tr>
       <tr>
         <td>width</td>
+        <td>string</td>
         <td></td>
-        <td></td>
-        <td>Custom width</td>
+        <td>Custom button width</td>
       </tr>
       <tr>
         <td>height</td>
+        <td>string</td>
         <td></td>
+        <td>Custom button height</td>
+      </tr>
+      <tr>
+        <td>iconWidth</td>
+        <td>string</td>
         <td></td>
-        <td>Custom height</td>
+        <td>(dato-icon-button) Custom icon width if not supplied button width will be taken.</td>
+      </tr>
+      <tr>
+        <td>height</td>
+        <td>string</td>
+        <td></td>
+        <td>(dato-icon-button) Custom icon height if not supplied button height will be taken.</td>
       </tr>
     </dato-api-table>
 


### PR DESCRIPTION
not to break backwards, If iconWidth/Height isn’t passed it will use the height and width set to the button