### PR TITLE
fix(dato-tooltip): minor tooltip changes

### DIFF
--- a/lib/src/directives/tooltip.directive.ts
+++ b/lib/src/directives/tooltip.directive.ts
@@ -36,12 +36,12 @@ export class DatoTooltipDirective implements OnDestroy, AfterViewInit {
   @Input() datoTooltipDelay = 0;
   @Input() datoTooltipClass = '';
   @Input() datoTooltipOnTextOverflow = false;
+  @Input() datoTooltipOverflowElement: ElementRef = null;
   @Input() datoTooltipDisabled = false;
   @Input() datoTooltipOverflow = false;
   @Input() datoTooltipOffset;
   @Input() datoIsManual = false;
   @Input() datoTooltipTrigger: TooltipTrigger = 'hover';
-  @Input() datoTooltipTarget: ElementRef = null;
 
   private content: string | HTMLElement;
   private tplPortal: DatoTemplatePortal;
@@ -63,7 +63,7 @@ export class DatoTooltipDirective implements OnDestroy, AfterViewInit {
   private tooltip;
 
   get tooltipElement(): HTMLElement {
-    return this.datoTooltipTarget || this.host.nativeElement;
+    return this.datoTooltipOverflowElement || this.host.nativeElement;
   }
 
   constructor(private host: ElementRef, private iconRegistry: IconRegistry) {}
@@ -122,7 +122,7 @@ export class DatoTooltipDirective implements OnDestroy, AfterViewInit {
 
   show() {
     if (this.tooltip) return;
-    this.tooltip = this.createTooltipInstance(this.tooltipElement).show();
+    this.tooltip = this.createTooltipInstance(this.host.nativeElement).show();
   }
 
   hide() {

--- a/lib/src/scss/themes/index.themes.scss
+++ b/lib/src/scss/themes/index.themes.scss
@@ -1,4 +1,4 @@
-$PRESERVE_THEMIFY: false;
+$PRESERVE_THEMIFY: true;
 @import '../../../../node_modules/@datorama/themify/themify.scss';
 
 $themeRules: (

--- a/playground/src/app/components-gallery/previews/tooltip-preview/tooltip-preview.component.html
+++ b/playground/src/app/components-gallery/previews/tooltip-preview/tooltip-preview.component.html
@@ -144,8 +144,7 @@
   <div datoTooltip="A tooltip for a nested span element"
        datoTooltipPosition="right"
        [datoTooltipOverflow]="true"
-       datoTooltipOffset="0 20"
-       [datoTooltipTarget]="nestedTooltipElement"
+       [datoTooltipOverflowElement]="nestedTooltipElement"
        class="different-tooltip-target first-row">
     <div style="padding: 10px">
       <div class="d-flex-column">
@@ -168,7 +167,7 @@
               datoTooltipPosition="right"
               class="bold"
               [datoTooltipOverflow]="true"
-              [datoTooltipTarget]="outerTooltipElement">Hovering me will trigger my container tooltip</span>
+              [datoTooltipOverflowElement]="outerTooltipElement">Hovering me will trigger my container tooltip</span>
       </div>
     </div>
   </div>
@@ -179,8 +178,7 @@
      <div datoTooltip="A tooltip for a nested span element"
           datoTooltipPosition="right"
           [datoTooltipOverflow]="true"
-          datoTooltipOffset="0 20"
-          [datoTooltipTarget]="nestedTooltipElement"
+          [datoTooltipOverflowElement]="nestedTooltipElement"
           class="different-tooltip-target first-row">
     <div style="padding: 10px">
       <div class="d-flex-column">
@@ -203,7 +201,7 @@
               datoTooltipPosition="right"
               class="bold"
               [datoTooltipOverflow]="true"
-              [datoTooltipTarget]="outerTooltipElement">Hovering me will trigger my container tooltip</span>
+              [datoTooltipOverflowElement]="outerTooltipElement">Hovering me will trigger my container tooltip</span>
       </div>
     </div>
   </div>
@@ -277,7 +275,7 @@
         <td>Set tooltip offset position</td>
       </tr>
       <tr>
-        <td>datoTooltipTarget</td>
+        <td>datoTooltipOverflowElement</td>
         <td>ElementRef</td>
         <td></td>
         <td>The element that the tooltip should open next to</td>


### PR DESCRIPTION
Rename datoTooltipTarget to datoTooltipOverflowElement.
Change position ref of the tooltip (Relative to tooltip element and not overflow element ref)